### PR TITLE
[DM] DM 목록 조회 및 DM Key 생성 로직 구현

### DIFF
--- a/src/main/java/com/ootd/fitme/domain/directmessage/controller/DirectMessageController.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/controller/DirectMessageController.java
@@ -1,12 +1,15 @@
 package com.ootd.fitme.domain.directmessage.controller;
 
 import com.ootd.fitme.domain.directmessage.controller.docs.DirectMessageControllerDocs;
+import com.ootd.fitme.domain.directmessage.dto.request.DirectMessageSearchCondition;
 import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDtoCursorResponse;
 import com.ootd.fitme.domain.directmessage.service.DirectMessageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
@@ -21,8 +24,10 @@ public class DirectMessageController implements DirectMessageControllerDocs {
     @Override
     @GetMapping
     public ResponseEntity<DirectMessageDtoCursorResponse> getDirectMessages(
-            UUID userId, String cursor, UUID idAfter, int limit) {
-        // TODO : 구현 예정
-        return null;
+            @RequestParam UUID userId,
+            @Valid DirectMessageSearchCondition condition) {
+        DirectMessageDtoCursorResponse response = directMessageService.getDirectMessages
+                (userId, condition.cursor(), condition.idAfter(), condition.limit());
+        return ResponseEntity.status(200).body(response);
     }
 }

--- a/src/main/java/com/ootd/fitme/domain/directmessage/controller/docs/DirectMessageControllerDocs.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/controller/docs/DirectMessageControllerDocs.java
@@ -1,5 +1,6 @@
 package com.ootd.fitme.domain.directmessage.controller.docs;
 
+import com.ootd.fitme.domain.directmessage.dto.request.DirectMessageSearchCondition;
 import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDtoCursorResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -10,5 +11,5 @@ import java.util.UUID;
 public interface DirectMessageControllerDocs {
 
     ResponseEntity<DirectMessageDtoCursorResponse> getDirectMessages(
-            UUID userId, String cursor, UUID idAfter, int limit);
+            UUID userId, DirectMessageSearchCondition condition);
 }

--- a/src/main/java/com/ootd/fitme/domain/directmessage/dto/request/DirectMessageSearchCondition.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/dto/request/DirectMessageSearchCondition.java
@@ -1,0 +1,11 @@
+package com.ootd.fitme.domain.directmessage.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record DirectMessageSearchCondition(
+        String cursor,
+        UUID idAfter,
+        @NotNull Integer limit
+) {}

--- a/src/main/java/com/ootd/fitme/domain/directmessage/entity/DirectMessage.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/entity/DirectMessage.java
@@ -35,4 +35,14 @@ public class DirectMessage extends BaseEntity {
         return new DirectMessage(senderId, receiverId, content);
     }
 
+    public static String createDmKey(UUID userId1, UUID userId2) {
+        String id1 = userId1.toString();
+        String id2 = userId2.toString();
+
+        if (id1.compareTo(id2) <= 0) {
+            return id1 + "_" + id2;
+        } else {
+            return id2 + "_" + id1;
+        }
+    }
 }

--- a/src/main/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepository.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepository.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 
 public interface DirectMessageRepository extends JpaRepository<DirectMessage, UUID>, DirectMessageRepositoryCustom {
 
+    long countBySenderIdOrReceiverId(UUID senderId, UUID receiverId);
 }

--- a/src/main/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepository.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface DirectMessageRepository extends JpaRepository<DirectMessage, UUID> {
-
+public interface DirectMessageRepository extends JpaRepository<DirectMessage, UUID>, DirectMessageRepositoryCustom {
 
 }

--- a/src/main/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepositoryCustom.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.ootd.fitme.domain.directmessage.repository;
+
+import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface DirectMessageRepositoryCustom {
+
+    List<DirectMessageDto> findDirectMessages(UUID userId, String cursor, UUID idAfter, int limit);
+
+
+}

--- a/src/main/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepositoryImpl.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.ootd.fitme.domain.directmessage.repository;
+
+import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
+import com.ootd.fitme.domain.directmessage.dto.response.UserSummary;
+import com.ootd.fitme.domain.directmessage.entity.QDirectMessage;
+import com.ootd.fitme.domain.profile.entity.QProfile;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class DirectMessageRepositoryImpl implements DirectMessageRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<DirectMessageDto> findDirectMessages(UUID userId, String cursor, UUID idAfter, int limit) {
+
+        QDirectMessage directMessage = QDirectMessage.directMessage;
+        QProfile senderProfile = new QProfile("senderProfile");
+        QProfile receiverProfile = new QProfile("receiverProfile");
+
+        return jpaQueryFactory
+                .select(
+                        Projections.constructor(DirectMessageDto.class,
+                                directMessage.id,
+                                directMessage.createdAt,
+                                Projections.constructor(UserSummary.class,
+                                        directMessage.senderId,
+                                        senderProfile.name,
+                                        senderProfile.profileImageUrl
+                                        ),
+                                Projections.constructor(UserSummary.class,
+                                        directMessage.receiverId,
+                                        receiverProfile.name,
+                                        receiverProfile.profileImageUrl
+                                        ),
+                                directMessage.content
+                                )
+                )
+                .from(directMessage)
+                .join(senderProfile).on(senderProfile.user.id.eq(directMessage.senderId))
+                .join(receiverProfile).on(receiverProfile.user.id.eq(directMessage.receiverId))
+                .where(
+                        directMessage.senderId.eq(userId).or(directMessage.receiverId.eq(userId)),
+                        cursorCondition(cursor, idAfter)
+                )
+                .orderBy(directMessage.createdAt.desc(), directMessage.id.asc())
+                .limit(limit + 1)
+                .fetch();
+    }
+    private BooleanExpression cursorCondition(String cursor, UUID idAfter) {
+        if (cursor == null || idAfter == null) return null;
+
+        Instant nextCursor = Instant.parse(cursor);
+        QDirectMessage directMessage = QDirectMessage.directMessage;
+        BooleanExpression condition = directMessage.createdAt.lt(nextCursor);
+        return condition.or(directMessage.createdAt.eq(nextCursor).and(directMessage.id.gt(idAfter)));
+
+    }
+}

--- a/src/main/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImpl.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImpl.java
@@ -3,11 +3,14 @@ package com.ootd.fitme.domain.directmessage.service;
 import com.ootd.fitme.domain.directmessage.dto.request.DirectMessageCreateRequest;
 import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
 import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDtoCursorResponse;
+import com.ootd.fitme.domain.directmessage.enums.SortBy;
+import com.ootd.fitme.domain.directmessage.enums.SortDirection;
 import com.ootd.fitme.domain.directmessage.repository.DirectMessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -27,7 +30,23 @@ public class DirectMessageServiceImpl implements DirectMessageService {
 
     @Override
     public DirectMessageDtoCursorResponse getDirectMessages(UUID userId, String cursor, UUID idAfter, int limit) {
-        // TODO : 구현 예정
-        return null;
+
+        List<DirectMessageDto> directMessages =
+                directMessageRepository.findDirectMessages(userId, cursor, idAfter, limit);
+
+        boolean hasNext = directMessages.size() > limit;
+        List<DirectMessageDto> messages = hasNext ? directMessages.subList(0, limit) : directMessages;
+
+        String nextCursor = null;
+        UUID nextIdAfter = null;
+
+        if (hasNext) {
+            DirectMessageDto lastItem = messages.get(messages.size() - 1);
+            nextCursor = lastItem.createdAt().toString();
+            nextIdAfter = lastItem.id();
+        }
+        // TODO : count 다시 구현하기
+        return new DirectMessageDtoCursorResponse(
+                messages, nextCursor, nextIdAfter, hasNext, 0, SortBy.createdAt, SortDirection.DESCENDING);
     }
 }

--- a/src/main/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImpl.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImpl.java
@@ -45,8 +45,10 @@ public class DirectMessageServiceImpl implements DirectMessageService {
             nextCursor = lastItem.createdAt().toString();
             nextIdAfter = lastItem.id();
         }
-        // TODO : count 다시 구현하기
+
+        long totalCount = directMessageRepository.countBySenderIdOrReceiverId(userId, userId);
+
         return new DirectMessageDtoCursorResponse(
-                messages, nextCursor, nextIdAfter, hasNext, 0, SortBy.createdAt, SortDirection.DESCENDING);
+                messages, nextCursor, nextIdAfter, hasNext, totalCount, SortBy.createdAt, SortDirection.DESCENDING);
     }
 }

--- a/src/test/java/com/ootd/fitme/domain/directmessage/controller/DirectMessageControllerTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/controller/DirectMessageControllerTest.java
@@ -1,0 +1,103 @@
+package com.ootd.fitme.domain.directmessage.controller;
+
+import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDtoCursorResponse;
+import com.ootd.fitme.domain.directmessage.enums.SortBy;
+import com.ootd.fitme.domain.directmessage.enums.SortDirection;
+import com.ootd.fitme.domain.directmessage.service.DirectMessageService;
+import com.ootd.fitme.global.security.jwt.JwtAuthenticationFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(
+        controllers = DirectMessageController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+class DirectMessageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DirectMessageService directMessageService;
+
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+    }
+
+    @Nested
+    @DisplayName("DM 목록 조회")
+    class GetDirectMessagesTest {
+
+        @Test
+        @DisplayName("성공 - DM 목록 조회 시 200을 반환한다")
+        void getDirectMessages_request_return200() throws Exception {
+
+            //given
+            DirectMessageDtoCursorResponse response = new DirectMessageDtoCursorResponse(
+                    List.of(), null, null,
+                    false, 0, SortBy.createdAt, SortDirection.DESCENDING);
+
+            given(directMessageService.getDirectMessages(any(), any(), any(), anyInt()))
+                    .willReturn(response);
+
+            //when & then
+            mockMvc.perform(get("/api/direct-messages")
+                    .param("userId", userId.toString())
+                    .param("limit", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.nextCursor").value(nullValue()))
+                    .andExpect(jsonPath("$.nextIdAfter").value(nullValue()))
+                    .andExpect(jsonPath("$.hasNext").value(false))
+                    .andExpect(jsonPath("$.totalCount").value(0))
+                    .andExpect(jsonPath("$.sortBy").value("createdAt"))
+                    .andExpect(jsonPath("$.sortDirection").value("DESCENDING"));
+        }
+
+        @Test
+        @DisplayName("실패 - userId가 없으면 400을 반환한다")
+        void getDirectMessages_notExistUserId_return400() throws Exception {
+
+            //when & then
+            mockMvc.perform(get("/api/direct-messages")
+                            .param("limit", "10"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패 - limit가 없으면 400을 반환한다")
+        void getDirectMessages_notExistLimit_return400() throws Exception {
+
+            //when & then
+            mockMvc.perform(get("/api/direct-messages")
+                            .param("userId", userId.toString()))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/com/ootd/fitme/domain/directmessage/entity/DirectMessageTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/entity/DirectMessageTest.java
@@ -1,0 +1,62 @@
+package com.ootd.fitme.domain.directmessage.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DirectMessageTest {
+
+    @Test
+    @DisplayName("성공 - 두 UUID는 오름차순으로 정렬되어 반환한다")
+    void createDmKey_smallerIdFirst_returnSmallerId() {
+
+        //given
+        UUID userId1 = UUID.fromString("89a71b30-e73f-415f-b791-e8cb9694e5b6");
+        UUID userId2 = UUID.fromString("96671e32-ff27-4215-bf96-d0575abc11f4");
+
+        //when
+        String dmKey = DirectMessage.createDmKey(userId1, userId2);
+
+        //then
+        assertThat(dmKey).isEqualTo(
+                "89a71b30-e73f-415f-b791-e8cb9694e5b6_96671e32-ff27-4215-bf96-d0575abc11f4");
+
+    }
+
+    @Test
+    @DisplayName("성공 - 큰 UUID가 앞에 와도 오름차순으로 정렬되어 반환된다")
+    void createDmKey_reverseOrder_returnSmallerId() {
+
+        //given
+        UUID userId1 = UUID.fromString("89a71b30-e73f-415f-b791-e8cb9694e5b6");
+        UUID userId2 = UUID.fromString("96671e32-ff27-4215-bf96-d0575abc11f4");
+
+        //when
+        String dmKey = DirectMessage.createDmKey(userId2, userId1);
+
+        //then
+        assertThat(dmKey).isEqualTo(
+                "89a71b30-e73f-415f-b791-e8cb9694e5b6_96671e32-ff27-4215-bf96-d0575abc11f4");
+
+    }
+
+
+    @Test
+    @DisplayName("성공 - 두 사용자의 순서가 바뀌어도 같은 key를 반환한다")
+    void createDmKey_orderChange_returnSameKey() {
+
+        //given
+        UUID userId1 = UUID.fromString("89a71b30-e73f-415f-b791-e8cb9694e5b6");
+        UUID userId2 = UUID.fromString("96671e32-ff27-4215-bf96-d0575abc11f4");
+
+        //when
+        String dmKey1 = DirectMessage.createDmKey(userId1, userId2);
+        String dmKey2 = DirectMessage.createDmKey(userId2, userId1);
+
+        //then
+        assertThat(dmKey1).isEqualTo(dmKey2);
+    }
+}

--- a/src/test/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepositoryTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.ootd.fitme.domain.directmessage.repository;
+
+
+import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
+import com.ootd.fitme.domain.directmessage.entity.DirectMessage;
+import com.ootd.fitme.domain.profile.entity.Profile;
+import com.ootd.fitme.domain.profile.repository.ProfileRepository;
+import com.ootd.fitme.domain.user.entity.User;
+import com.ootd.fitme.domain.user.repository.UserRepository;
+import com.ootd.fitme.global.config.JpaAuditingConfig;
+import com.ootd.fitme.global.config.QuerydslConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("local")
+@Import({JpaAuditingConfig.class, QuerydslConfig.class})
+class DirectMessageRepositoryTest {
+
+    @Autowired
+    private DirectMessageRepository directMessageRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @Nested
+    @DisplayName("DM 목록 조회")
+    class GetDirectMessagesTest {
+
+        UUID senderId;
+        UUID receiverId;
+
+        @BeforeEach
+        void setup() {
+            User sender = userRepository.save(User.create("sender@a.com", "123456"));
+            User receiver = userRepository.save(User.create("receiver.com", "123456"));
+            senderId = sender.getId();
+            receiverId = receiver.getId();
+            saveProfile(sender, "sender");
+            saveProfile(receiver, "receiver");
+        }
+
+        @Test
+        @DisplayName("limit + 1개를 조회한다")
+        void findDirectMessages_return_limitPlusOne(){
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "테스트 메시지1"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "테스트 메시지2"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "테스트 메시지3"));
+
+            //when
+            List<DirectMessageDto> directMessages = directMessageRepository.findDirectMessages(
+                    senderId, null, null, 2);
+
+            //then
+            assertThat(directMessages.size()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("cursor로 다음 페이지를 조회한다")
+        void findDirectMessages_cursor_returnNextPage() {
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "테스트 메시지1"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "테스트 메시지2"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "테스트 메시지3"));
+
+            List<DirectMessageDto> firstPage = directMessageRepository.findDirectMessages(
+                    senderId, null, null, 2);
+
+            String cursor = firstPage.get(1).createdAt().toString();
+            UUID idAfter = firstPage.get(1).id();
+
+            //when
+            List<DirectMessageDto> secondPage = directMessageRepository.findDirectMessages(
+                    senderId, cursor, idAfter, 2);
+
+            //then
+            assertThat(secondPage.size()).isEqualTo(1);
+        }
+    }
+
+    private void saveProfile(User user, String name) {
+        profileRepository.save(Profile.create(
+                name, null, null, 0, 0,
+                null, null, null,
+                null, null, null,
+                user));
+    }
+}

--- a/src/test/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepositoryTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/repository/DirectMessageRepositoryTest.java
@@ -47,7 +47,7 @@ class DirectMessageRepositoryTest {
         @BeforeEach
         void setup() {
             User sender = userRepository.save(User.create("sender@a.com", "123456"));
-            User receiver = userRepository.save(User.create("receiver.com", "123456"));
+            User receiver = userRepository.save(User.create("receiver@a.com", "123456"));
             senderId = sender.getId();
             receiverId = receiver.getId();
             saveProfile(sender, "sender");

--- a/src/test/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImplTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImplTest.java
@@ -1,0 +1,185 @@
+package com.ootd.fitme.domain.directmessage.service;
+
+import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDtoCursorResponse;
+import com.ootd.fitme.domain.directmessage.entity.DirectMessage;
+import com.ootd.fitme.domain.directmessage.repository.DirectMessageRepository;
+import com.ootd.fitme.domain.profile.entity.Profile;
+import com.ootd.fitme.domain.profile.repository.ProfileRepository;
+import com.ootd.fitme.domain.user.entity.User;
+import com.ootd.fitme.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("local")
+@Transactional
+class DirectMessageServiceImplTest {
+
+    @Autowired
+    private DirectMessageServiceImpl directMessageServiceImpl;
+
+    @Autowired
+    private DirectMessageRepository directMessageRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @Nested
+    @DisplayName("DM 목록 조회")
+    class GetDirectMessagesTest {
+
+        private UUID senderId;
+        private UUID receiverId;
+
+        @BeforeEach
+        void setup() {
+            User sender = userRepository.save(User.create("sender@test.com", "123456"));
+            User receiver = userRepository.save(User.create("receiver@test.com", "123456"));
+            senderId = sender.getId();
+            receiverId = receiver.getId();
+
+            saveProfile(sender, "보내는사람");
+            saveProfile(receiver, "받는사람");
+        }
+
+        @Test
+        @DisplayName("성공 - sender로 조회하면 DM이 반환된다")
+        void getDirectMessages_sender_returnDirectMessages() {
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "하이"));
+
+            //when
+            DirectMessageDtoCursorResponse directMessages = directMessageServiceImpl.getDirectMessages(
+                    senderId, null, null, 10);
+
+            //then
+            assertThat(directMessages).isNotNull();
+            assertThat(directMessages.data().size()).isEqualTo(1);
+            assertThat(directMessages.data().get(0).sender().userId()).isEqualTo(senderId);
+        }
+
+        @Test
+        @DisplayName("성공 - receiver로 조회하면 DM이 반환된다")
+        void getDirectMessages_receiver_returnDirectMessages() {
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "잘가"));
+
+            //when
+            DirectMessageDtoCursorResponse directMessages = directMessageServiceImpl.getDirectMessages(
+                    receiverId, null, null, 10);
+
+            //then
+            assertThat(directMessages).isNotNull();
+            assertThat(directMessages.data().size()).isEqualTo(1);
+            assertThat(directMessages.data().get(0).receiver().userId()).isEqualTo(receiverId);
+        }
+
+        @Test
+        @DisplayName("성공 - 데이터가 limit보다 많으면 hasNext가 true이다")
+        void getDirectMessages_sizeOverLimit_hasNextTrue() {
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트1"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트2"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트3"));
+
+            //when
+            DirectMessageDtoCursorResponse directMessages = directMessageServiceImpl.getDirectMessages(
+                    senderId, null, null, 2);
+
+            //then
+            assertThat(directMessages.hasNext()).isTrue();
+            assertThat(directMessages.data().size()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("성공 - 데이터가 limit보다 적으면 hasNext가 false이다")
+        void getDirectMessages_sizeUnderLimit_hasNextFalse() {
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트1"));
+
+            //when
+            DirectMessageDtoCursorResponse directMessages = directMessageServiceImpl.getDirectMessages(
+                    senderId, null, null, 2);
+
+            //then
+            assertThat(directMessages.hasNext()).isFalse();
+            assertThat(directMessages.data().size()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("성공 - 데이터가 0개면 빈 리스트를 반환한다")
+        void getDirectMessages_dataEmpty_returnList() {
+
+            //when
+            DirectMessageDtoCursorResponse directMessages = directMessageServiceImpl.getDirectMessages(
+                    senderId, null, null, 2);
+
+            //then
+            assertThat(directMessages.data()).isEmpty();
+            assertThat(directMessages.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공 - hasNext가 true이면 nextCursor가 null이 아니다")
+        void getDirectMessages_hasNextTrue_nextCursorNotNull() {
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트1"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트2"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트3"));
+
+            //when
+            DirectMessageDtoCursorResponse directMessages = directMessageServiceImpl.getDirectMessages(
+                    senderId, null, null, 2);
+
+            //then
+            assertThat(directMessages.hasNext()).isTrue();
+            assertThat(directMessages.nextCursor()).isNotNull();
+            assertThat(directMessages.nextIdAfter()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("성공 - hasNext가 false이면 nextCursor가 null이다")
+        void getDirectMessages_hasNextFalse_nextCursorNull() {
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트1"));
+
+            //when
+            DirectMessageDtoCursorResponse directMessages = directMessageServiceImpl.getDirectMessages(
+                    senderId, null, null, 2);
+
+            //then
+            assertThat(directMessages.hasNext()).isFalse();
+            assertThat(directMessages.nextCursor()).isNull();
+            assertThat(directMessages.nextIdAfter()).isNull();
+        }
+
+    }
+
+    private void saveProfile(User user, String name) {
+        profileRepository.save(Profile.create(
+                name, null, null, 0, 0,
+                null, null, null,
+                null, null, null,
+                user));
+    }
+
+}

--- a/src/test/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImplTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImplTest.java
@@ -172,6 +172,22 @@ class DirectMessageServiceImplTest {
             assertThat(directMessages.nextIdAfter()).isNull();
         }
 
+        @Test
+        @DisplayName("성공 - totalCount는 전체 DM 개수를 반환한다")
+        void getDirectMessages_totalCount_returnTotalCount() {
+
+            //given
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트1"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트2"));
+            directMessageRepository.save(DirectMessage.create(senderId, receiverId, "DM 테스트3"));
+
+            //when
+            DirectMessageDtoCursorResponse directMessages = directMessageServiceImpl.getDirectMessages(
+                    senderId, null, null, 2);
+
+            //then
+            assertThat(directMessages.totalCount()).isEqualTo(3);
+        }
     }
 
     private void saveProfile(User user, String name) {

--- a/src/test/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceUnitTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceUnitTest.java
@@ -1,0 +1,46 @@
+package com.ootd.fitme.domain.directmessage.service;
+
+import com.ootd.fitme.domain.directmessage.repository.DirectMessageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class DirectMessageServiceUnitTest {
+
+    @Mock
+    private DirectMessageRepository directMessageRepository;
+
+    @InjectMocks
+    private DirectMessageServiceImpl directMessageServiceImpl;
+
+    @Nested
+    @DisplayName("DM 목록 조회")
+    class GetDirectMessagesTest {
+
+        @Test
+        @DisplayName("성공 - getDirectMessage 호출 시 findDirectMessages가 호출된다")
+        void getDirectMessages_called_findDirectMessages() {
+
+            //given
+            UUID userId = UUID.randomUUID();
+            int limit = 5;
+
+            //when
+            directMessageServiceImpl.getDirectMessages(userId, null, null, limit);
+
+            //then
+            then(directMessageRepository).should().findDirectMessages(eq(userId), any(), any(), eq(limit));
+        }
+    }
+}


### PR DESCRIPTION
## PR 타입

- [x] Feat: 새로운 기능 추가
- [ ] Add : 새로운 파일/내용 추가
- [ ] Bug : 버그 발견
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링
- [x] Test : 테스트 코드 추가
- [ ] Chore : 자잘한 수정이나 빌드 업데이트 / 설정 변경
- [ ] Remove : 파일 삭제

## 변경사항

- DM 목록 조회 - QueryDSL 기반 커서 페이지네이션 구현
- DM Key 생성 로직 - 두 사용자 UUID를 오름차순 정렬 후 "_" 연결 로직 구현
- 테스트 코드 작성