### PR TITLE
[날씨 관리] 위도 경도 매핑 오류 수정

### DIFF
--- a/src/main/java/com/ootd/fitme/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/com/ootd/fitme/domain/region/service/RegionServiceImpl.java
@@ -24,8 +24,8 @@ public class RegionServiceImpl implements RegionService {
     public Region resolveAndUpsert(double longitude, double latitude) {
         KakaoLocalClient.RegionInfo info = kakaoLocalClient.resolveRegion(longitude, latitude);
 
-        Integer x = (int) Math.round(latitude);
-        Integer y = (int) Math.round(longitude);
+        Integer x = (int) Math.round(info.longitude());
+        Integer y = (int) Math.round(info.latitude());
 
         return regionRepository.findByRegionCode(info.regionCode())
                 .map(existing -> {

--- a/src/test/java/com/ootd/fitme/domain/region/service/RegionServiceUnitTest.java
+++ b/src/test/java/com/ootd/fitme/domain/region/service/RegionServiceUnitTest.java
@@ -58,8 +58,8 @@ public class RegionServiceUnitTest {
 
             assertThat(result.getRegionCode()).isEqualTo("1111061500");
             assertThat(result.getRegionFullName()).isEqualTo("서울 종로구 청운효자동");
-            assertThat(result.getX()).isEqualTo((int) Math.round(37.5841));
-            assertThat(result.getY()).isEqualTo((int) Math.round(126.9707));
+            assertThat(result.getX()).isEqualTo((int) Math.round(126.9707));
+            assertThat(result.getY()).isEqualTo((int) Math.round(37.5841));
 
             ArgumentCaptor<Region> captor = ArgumentCaptor.forClass(Region.class);
             verify(regionRepository).save(captor.capture());
@@ -101,8 +101,8 @@ public class RegionServiceUnitTest {
             assertThat(result).isSameAs(existing);
             assertThat(existing.getRegionFullName()).isEqualTo("서울 종로구 청운효자동");
             assertThat(existing.getRegion1depthName()).isEqualTo("서울");
-            assertThat(existing.getX()).isEqualTo((int) Math.round(37.5841));
-            assertThat(existing.getY()).isEqualTo((int) Math.round(126.9707));
+            assertThat(existing.getX()).isEqualTo((int) Math.round(126.9707));
+            assertThat(existing.getY()).isEqualTo((int) Math.round(37.5841));
 
             verify(regionRepository, never()).save(any(Region.class));
         }
@@ -130,8 +130,8 @@ public class RegionServiceUnitTest {
 
         assertThat(location.latitude()).isEqualTo(37.5841);
         assertThat(location.longitude()).isEqualTo(126.9707);
-        assertThat(location.x()).isEqualTo((int) Math.round(37.5841));
-        assertThat(location.y()).isEqualTo((int) Math.round(126.9707));
+        assertThat(location.x()).isEqualTo((int) Math.round(126.9707));
+        assertThat(location.y()).isEqualTo((int) Math.round(37.5841));
         assertThat(location.locationNames()).containsExactly("서울", "종로구", "청운효자동");
     }
 }


### PR DESCRIPTION
## PR 타입

- [ ] Feat: 새로운 기능 추가
- [ ] Add : 새로운 파일/내용 추가
- [ ] Bug : 버그 발견
- [x] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링
- [ ] Test : 테스트 코드 추가
- [ ] Chore : 자잘한 수정이나 빌드 업데이트 / 설정 변경
- [ ] Remove : 파일 삭제

## 변경사항
- 위도/경도와 x/y의 매핑이 반대로 되있던걸 수정했습니다.
-