### PR TITLE
fix: compose.yml 내 healthcheck 설정 수정 및 nginx.conf 경로 변경

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -20,8 +20,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 40s
+      retries: 15
+      start_period: 90s
     depends_on:
       postgres: # postgres라는 동작에 의존하고 이게 될때까지 위의서비스는 대기
         condition: service_healthy # 해당 서비스(postgres)가 healthy해야만 동작하도록 조건 추가 및 대기
@@ -119,10 +119,11 @@ services:
     volumes:
       - fitme-elasticsearch-data:/usr/share/elasticsearch/data
     healthcheck:
-      test: [ "CMD-SHELL", "curl -fsS http://localhost:9200 >/dev/null || exit 1" ]
+      test: [ "CMD-SHELL", "curl -fsS http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s >/dev/null || exit 1" ]
       interval: 15s
       timeout: 10s
-      retries: 10
+      retries: 15
+      start_period: 90s
     networks:
       - fitme-backend-network
 
@@ -131,7 +132,7 @@ services:
     ports:
       - "80:80" # 외부 요청(80)을 nginx로 받고 → 내부 app:8080으로 프록시
     volumes:
-      - ./nginx/nginx.conf.local:/etc/nginx/nginx.conf.local:ro
+      - ./nginx/nginx.conf.local:/etc/nginx/nginx.conf:ro
     depends_on:
       app:
         condition: service_healthy


### PR DESCRIPTION


## PR 타입

- [ ] Feat: 새로운 기능 추가
- [ ] Add : 새로운 파일/내용 추가
- [ ] Bug : 버그 발견
- [x] Fix : 버그 수정
- [x] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링
- [ ] Test : 테스트 코드 추가
- [ ] Chore : 자잘한 수정이나 빌드 업데이트 / 설정 변경
- [ ] Remove : 파일 삭제

## 변경사항
로컬환경에서 빌드시 healthcheck 총 주기가 짧아 errror처리되는부분 시간 연장
- healthcheck retries 및 start_period 값 변경: 10 → 15, 40s → 90s
- Elasticsearch healthcheck에 wait_for_status=yellow 추가
- nginx.conf 경로 오타 수정: nginx.conf.local → nginx.conf