### PR TITLE
[DM] WebSocket DM Redis pub/sub 교체

### DIFF
--- a/src/main/java/com/ootd/fitme/domain/directmessage/listener/DirectMessageWebSocketEventListener.java
+++ b/src/main/java/com/ootd/fitme/domain/directmessage/listener/DirectMessageWebSocketEventListener.java
@@ -2,10 +2,9 @@ package com.ootd.fitme.domain.directmessage.listener;
 
 import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
 import com.ootd.fitme.domain.directmessage.dto.response.UserSummary;
-import com.ootd.fitme.domain.directmessage.entity.DirectMessage;
 import com.ootd.fitme.domain.directmessage.event.DirectMessageCreateEvent;
+import com.ootd.fitme.infrastructure.realtime.websocket.DmRedisPublisher;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -14,7 +13,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class DirectMessageWebSocketEventListener {
 
-    private final SimpMessagingTemplate messagingTemplate;
+    private final DmRedisPublisher dmRedisPublisher;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDirectMessageSent(DirectMessageCreateEvent event) {
@@ -26,9 +25,6 @@ public class DirectMessageWebSocketEventListener {
                 new UserSummary(event.receiverId(), event.receiverName(), event.receiverProfileImageUrl()),
                 event.message());
 
-        String dmKey = DirectMessage.createDmKey(
-                event.senderId(), event.receiverId());
-
-        messagingTemplate.convertAndSend("/sub/direct-messages_" + dmKey, dmData);
+        dmRedisPublisher.publish(dmData);
     }
 }

--- a/src/main/java/com/ootd/fitme/global/config/RedisConfig.java
+++ b/src/main/java/com/ootd/fitme/global/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.ootd.fitme.global.config;
+
+import com.ootd.fitme.infrastructure.realtime.websocket.DmRedisSubscriber;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(DmRedisSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "handleMessage");
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "spring.cache.type", havingValue = "redis")
+    public RedisMessageListenerContainer listenerContainer(
+            RedisConnectionFactory factory, MessageListenerAdapter listenerAdapter) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(factory);
+        container.addMessageListener(listenerAdapter, new ChannelTopic("dm:messages"));
+        return container;
+    }
+}

--- a/src/main/java/com/ootd/fitme/infrastructure/realtime/websocket/DmRedisPublisher.java
+++ b/src/main/java/com/ootd/fitme/infrastructure/realtime/websocket/DmRedisPublisher.java
@@ -1,0 +1,32 @@
+package com.ootd.fitme.infrastructure.realtime.websocket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DmRedisPublisher {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void publish(DirectMessageDto dmData) {
+        try {
+            String message = objectMapper.writeValueAsString(dmData);
+            stringRedisTemplate.convertAndSend("dm:messages", message);
+            log.info("DM Redis 발행 성공. senderId={}, receiverId={}",
+                    dmData.sender().userId(), dmData.receiver().userId());
+        } catch (JsonProcessingException e) {
+            log.error("DM Redis 발행 실패. senderId={}, receiverId={}",
+                    dmData.sender().userId(), dmData.receiver().userId(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/ootd/fitme/infrastructure/realtime/websocket/DmRedisSubscriber.java
+++ b/src/main/java/com/ootd/fitme/infrastructure/realtime/websocket/DmRedisSubscriber.java
@@ -1,0 +1,34 @@
+package com.ootd.fitme.infrastructure.realtime.websocket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
+import com.ootd.fitme.domain.directmessage.entity.DirectMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DmRedisSubscriber {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void handleMessage(String message) {
+        try {
+            DirectMessageDto dmData = objectMapper.readValue(message, DirectMessageDto.class);
+
+            String dmKey = DirectMessage.createDmKey(dmData.sender().userId(), dmData.receiver().userId());
+
+            messagingTemplate.convertAndSend("/sub/direct-messages_" + dmKey, dmData);
+
+            log.info("DM redis 수신 성공. senderId={}, receiverId={}",
+                    dmData.sender().userId(), dmData.receiver().userId());
+        } catch (JsonProcessingException e) {
+            log.error("Dm redis 수신 실패", e);
+        }
+    }
+}

--- a/src/test/java/com/ootd/fitme/domain/directmessage/listener/DirectMessageWebSocketEventListenerUnitTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/listener/DirectMessageWebSocketEventListenerUnitTest.java
@@ -1,26 +1,26 @@
 package com.ootd.fitme.domain.directmessage.listener;
 
 import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
-import com.ootd.fitme.domain.directmessage.dto.response.UserSummary;
 import com.ootd.fitme.domain.directmessage.event.DirectMessageCreateEvent;
+import com.ootd.fitme.infrastructure.realtime.websocket.DmRedisPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.time.Instant;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class DirectMessageWebSocketEventListenerUnitTest {
 
     @Mock
-    private SimpMessagingTemplate messagingTemplate;
+    private DmRedisPublisher dmRedisPublisher;
 
     @InjectMocks
     private DirectMessageWebSocketEventListener eventListener;
@@ -41,18 +41,11 @@ class DirectMessageWebSocketEventListenerUnitTest {
                 "받는사람", null,
                 "안녕하세요", now);
 
-        DirectMessageDto messageDto = new DirectMessageDto(
-                messageId, now,
-                new UserSummary(senderId, "보내는사람", null),
-                new UserSummary(receiverId, "받는사람", null),
-                "안녕하세요");
-
         //when
         eventListener.handleDirectMessageSent(event);
 
         //then
-        String channel = "/sub/direct-messages_89a71b30-e73f-415f-b791-e8cb9694e5b6_96671e32-ff27-4215-bf96-d0575abc11f4";
-        then(messagingTemplate).should().convertAndSend(channel, messageDto);
+        then(dmRedisPublisher).should().publish(any(DirectMessageDto.class));
     }
 
 }

--- a/src/test/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImplTest.java
+++ b/src/test/java/com/ootd/fitme/domain/directmessage/service/DirectMessageServiceImplTest.java
@@ -1,7 +1,6 @@
 package com.ootd.fitme.domain.directmessage.service;
 
 import com.ootd.fitme.domain.directmessage.dto.request.DirectMessageCreateRequest;
-import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDto;
 import com.ootd.fitme.domain.directmessage.dto.response.DirectMessageDtoCursorResponse;
 import com.ootd.fitme.domain.directmessage.entity.DirectMessage;
 import com.ootd.fitme.domain.directmessage.repository.DirectMessageRepository;
@@ -9,21 +8,18 @@ import com.ootd.fitme.domain.profile.entity.Profile;
 import com.ootd.fitme.domain.profile.repository.ProfileRepository;
 import com.ootd.fitme.domain.user.entity.User;
 import com.ootd.fitme.domain.user.repository.UserRepository;
-import com.ootd.fitme.global.security.auth.CustomUserPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest


### PR DESCRIPTION
## PR 타입

- [x] Feat: 새로운 기능 추가
- [ ] Add : 새로운 파일/내용 추가
- [ ] Bug : 버그 발견
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링
- [x] Test : 테스트 코드 추가
- [ ] Chore : 자잘한 수정이나 빌드 업데이트 / 설정 변경
- [ ] Remove : 파일 삭제

## 변경사항

- 모든 인스턴스가 메시지를 수신 한 뒤 해당 인스턴스에 연결된 세션으로만 전달되는 구조로 변경
- Simplebroker -> Redis pub/sub 교체
<img width="1174" height="125" alt="캡처" src="https://github.com/user-attachments/assets/23f62fae-daf3-41b0-87f6-c0a0e2f127d2" />

- 단일 인스턴스 및 멀티 인스터스 테스트 확인
