### PR TITLE
[인프라] Prometheus + grafana 모니터링 로컬 환경 구성 추가

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -161,6 +161,30 @@ services:
       - fitme-backend-network
     platform: linux/amd64
 
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro # 컨테이너 안에서 Prometheus가 읽는 고정 경로
+      - fitme-prometheus-data:/prometheus # 수집한 메트릭 데이터 볼륨 저장, 고정 경로
+    networks:
+      - fitme-backend-network
+
+  grafana:
+    image: grafana/grafana:11.0.3
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./monitoring/grafana/grafana.yml:/etc/grafana/provisioning/datasources/datasource.yml
+      - fitme-grafana-data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+    networks:
+      - fitme-backend-network
 
 
 # 볼륨 정의, local일경우 생략가능하지만 명시
@@ -176,6 +200,10 @@ volumes:
   fitme-kafka-data:
     driver: local
   fitme-elasticsearch-data:
+    driver: local
+  fitme-prometheus-data:
+    driver: local
+  fitme-grafana-data:
     driver: local
 
 # 네트워크 설정

--- a/monitoring/grafana/Dockerfile.grafana
+++ b/monitoring/grafana/Dockerfile.grafana
@@ -1,0 +1,5 @@
+FROM grafana/grafana:11.0.3
+
+COPY grafana.yml /etc/grafana/provisioning/datasources/datasource.yml
+
+EXPOSE 3000

--- a/monitoring/grafana/grafana.yml
+++ b/monitoring/grafana/grafana.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090  # Docker 내부 네트워크로 Prometheus 연결
+    isDefault: true              # 기본 데이터소스로 설정
+    editable: true # yml에서 프로비저닝하면 데이터소스가 잠기지만 UI에서도 수정 가능하게

--- a/monitoring/prometheus/Dockerfile.prometheus
+++ b/monitoring/prometheus/Dockerfile.prometheus
@@ -1,0 +1,5 @@
+FROM prom/prometheus:v2.53.0
+
+COPY prometheus-prod.yml /etc/prometheus/prometheus.yml
+
+EXPOSE 9090

--- a/monitoring/prometheus/prometheus-prod.yml
+++ b/monitoring/prometheus/prometheus-prod.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'fitme-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['fitme-app:8080']

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'fitme-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['app:8080'] # 컴포즈 서비스명


### PR DESCRIPTION
## PR 타입

- [x] Feat: 새로운 기능 추가
- [x] Add : 새로운 파일/내용 추가
- [ ] Bug : 버그 발견
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링
- [ ] Test : 테스트 코드 추가
- [ ] Chore : 자잘한 수정이나 빌드 업데이트 / 설정 변경
- [ ] Remove : 파일 삭제

## 변경사항

- prometheus 로컬 메트릭 수집 추가 설정
- grafana 모니터링 항목(도메인 별 요청, CPU 사용률, DB 커넥션 수 등) 커스텀 수정
- localhost:3000 grafana 접속, 로컬 환경에선 ID, PW 공개되어도 무관하다고 생각해 id,pw admin으로 통일했습니다.